### PR TITLE
Typo fix

### DIFF
--- a/generate-certificates.ps1
+++ b/generate-certificates.ps1
@@ -130,7 +130,7 @@ foreach($i in $HostNames){
    & "$keytool" "-keystore" "$i-node-keystore.jks" "-alias" "$i" "-certreq" "-file" "$i.csr" "-keypass" "$Password" "-storepass" "$Password"
 
    # Add both hostname and IP as subject alternative name
-   Write-Host "subjectAltName=DNS:$i,IP:$nodeIp" | Out-File -Encoding "UTF8" "$i.conf"
+   Write-Host "subjectAltName=DNS:$i,IP:$NodeIp" | Out-File -Encoding "UTF8" "$i.conf"
 
    # Sign the node certificate with the private key of the rootCA
    Write-Host "Signing certificate with Root CA certificate"


### PR DESCRIPTION
Typo fix in a variable name. In powershell variable names are case insensitive but it's clearer and less confusing to be consistent.