### PR TITLE
Bug fix: scripts failed when password contained '$'

### DIFF
--- a/generate-certificates.ps1
+++ b/generate-certificates.ps1
@@ -139,14 +139,14 @@ Write-Host "Generating the root certificate"
 "[ req ]
 distinguished_name  = req_distinguished_name
 prompt              = no
-output_password     = $Password
+output_password     = `"$Password`"
 default_bits        = $KeySize
 
 [ req_distinguished_name ]
 C     = BE
 O     = $Database
 CN    = rootCA
-OU    = $ClusterName" | Out-File -Encoding "UTF8" rootCA.conf
+OU    = `"$ClusterName`"" | Out-File -Encoding "UTF8" rootCA.conf
 
 # Create a new Root CA certificate and store the private key in rootCA.key, public key in rootCA.crt
 & "$openssl" "req" "-config" "rootCA.conf" "-new" "-x509" "-nodes" "-keyout" "rootCA.key" "-out" "rootCA.crt" "-days" "$Validity"

--- a/generate-certificates.sh
+++ b/generate-certificates.sh
@@ -130,14 +130,14 @@ echo 'Generating new Root CA certificate'
 echo "[req]
 distinguished_name  = req_distinguished_name
 prompt              = no
-output_password     = $pwd
+output_password     = \"$pwd\"
 default_bits        = $keySize
 
 [req_distinguished_name]
 C     = BE
 O     = $database
 CN    = rootCA
-OU    = $clusterName" > generate_rootCA.conf
+OU    = \"$clusterName\"" > generate_rootCA.conf
 
 # Create a new Root CA certificate and store the private key in rootCA.key, public key in rootCA.crt
 openssl req -config generate_rootCA.conf -new -x509 -nodes -keyout rootCA.key -out rootCA.crt -days $validity


### PR DESCRIPTION
The scripts failed when the password or clustername contained '$'. This can cause hard to debug issues when using passwords generated by a password manager. Escaping these strings in the config file fixes the issue.